### PR TITLE
fix: wrong hex color

### DIFF
--- a/src/styles/colors/brand.ts
+++ b/src/styles/colors/brand.ts
@@ -14,7 +14,7 @@ const brandColors = {
   },
   secondary: {
     25: "#FFF7F0",
-    50: "##FFF1E5",
+    50: "#FFF1E5",
     100: "#FFE7D6",
     200: "#FFCAA5",
     300: "#FFA86D",


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
Broken hex color for secondary 50

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
